### PR TITLE
Re-enabled CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,26 @@
 language: php
 
-php:
-    - 5.5
-    - 5.6
-    - 7.0
-
 env:
-    - DB=MYSQL CORE_RELEASE=master
+  global:
+    - DB=MYSQL CORE_RELEASE=integrate-react CORE_INSTALLER_RELEASE=master CORE_ALIAS=4.0.x-dev
+
+matrix:
+  include:
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+      env:
+    - php: 7.0
+      env: NPM_TEST=1
+  allow_failures:
+    - php: 7.0
+      env:
 
 before_script:
-    - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
+    - git clone -b "pulls/alias-and-installer-branch" git://github.com/chillu/silverstripe-travis-support.git ~/travis-support
     - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
     - cd ~/builds/ss
 
 script:
-    - vendor/bin/phpunit asset-admin/tests/php
-    - cd asset-admin
-    - nvm install 4.1
-    - npm install
-    - npm run test
-
-branches:
-    only:
-        - master
-
-matrix:
-    allow_failures:
-        - php: 7.0
+    - "if [ \"$NPM_TEST\" = \"\" ]; then vendor/bin/phpunit asset-admin/tests/php; fi"
+    - "if [ \"$NPM_TEST\" = \"1\" ]; then cd asset-admin; nvm install 4.1; npm install; npm run test; fi"

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
 	"type": "silverstripe-module",
 	"require": {
 		"php": ">=5.4.0",
-		"silverstripe/cms": "^4.0",
-		"silverstripe/framework": "^4.0"
+		"silverstripe/cms": "dev-integrate-react",
+		"silverstripe/framework": "dev-integrate-react"
 	},
 	"require-dev": {
 		"phpunit/PHPUnit": "^3.7"
@@ -17,5 +17,15 @@
 		"classmap": ["tests/behat/"]
 	},
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "https://github.com/open-sausages/silverstripe-cms.git"
+		},
+		{
+			"type": "vcs",
+			"url": "https://github.com/open-sausages/silverstripe-framework.git"
+		}
+	]
 }

--- a/tests/php/AssetGalleryFieldTest.php
+++ b/tests/php/AssetGalleryFieldTest.php
@@ -8,7 +8,7 @@ class AssetGalleryFieldTest extends SapphireTest {
 	/**
 	 * @var string
 	 */
-	public static $fixture_file = 'asset-gallery-field/tests/php/AssetGalleryFieldTest.yml';
+	public static $fixture_file = 'AssetGalleryFieldTest.yml';
 
 	public function testHasAttributes() {
 		$field = new AssetGalleryField("Files1");


### PR DESCRIPTION
Requires some weird Travis hacks, but should serve us well for the next month or so until the underlying `framework` and `cms` changes required by this new module can be merged back.

See https://github.com/silverstripe-labs/silverstripe-travis-support/pull/27