### PR TITLE
Remove outdated requirement: bundle-react

### DIFF
--- a/code/AssetGalleryField.php
+++ b/code/AssetGalleryField.php
@@ -503,7 +503,6 @@ class AssetGalleryField extends FormField
         $name = $this->getName();
 
         Requirements::css(ASSET_ADMIN_DIR . "/javascript/dist/main.css");
-        Requirements::javascript(FRAMEWORK_DIR . "/admin/javascript/dist/bundle-react.js");
         Requirements::add_i18n_javascript(ASSET_ADMIN_DIR . "/javascript/lang");
         Requirements::javascript(ASSET_ADMIN_DIR . "/javascript/dist/bundle.js");
 

--- a/code/controllers/AssetAdmin.php
+++ b/code/controllers/AssetAdmin.php
@@ -82,7 +82,6 @@ class AssetAdmin extends LeftAndMain implements PermissionProvider
     {
         parent::init();
 
-        Requirements::javascript(FRAMEWORK_DIR . "/admin/javascript/dist/bundle-react.js");
         Requirements::javascript(ASSET_ADMIN_DIR . "/javascript/AssetAdmin.js");
         Requirements::add_i18n_javascript(ASSET_ADMIN_DIR . '/javascript/lang', false, true);
         Requirements::css(ASSET_ADMIN_DIR . "/javascript/dist/main.css");


### PR DESCRIPTION
React is now included in bundle-lib, so shouldn't be required here